### PR TITLE
Add custom questions and foldernames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@visormatt/generator",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/.generator.config
+++ b/src/.generator.config
@@ -3,5 +3,6 @@
   "domain": "<%= domain %>",
   "organization": "<%= organization %>",
   "questions": ["name"],
+  "folder": "name",
   "templates": "<%= templates %>"
 }

--- a/src/.generator.config
+++ b/src/.generator.config
@@ -2,5 +2,6 @@
   "author": "<%= author %>",
   "domain": "<%= domain %>",
   "organization": "<%= organization %>",
+  "questions": ["name"],
   "templates": "<%= templates %>"
 }

--- a/src/__test__/generator.test.ts
+++ b/src/__test__/generator.test.ts
@@ -70,14 +70,27 @@ describe('generator', () => {
    */
   describe('createQuestions', () => {
     const templatePath = '/path/to/templates';
+    const templateQuestions = ['name', 'test'];
 
     it('should return 2 questions', async () => {
       const questions = await createQuestions({ templates: templatePath });
       expect(questions).toHaveLength(2);
     });
 
+    it('should return 3 questions', async () => {
+      const questions = await createQuestions({
+        questions: templateQuestions,
+        templates: templatePath
+      });
+      expect(questions).toHaveLength(3);
+    });
+
     it('should call "fs.readdirSync" to get the templates', async () => {
-      await createQuestions({ templates: templatePath });
+      await createQuestions({
+        questions: templateQuestions,
+        templates: templatePath
+      });
+
       expect(readdirSync).toHaveBeenCalledWith(templatePath);
     });
   });

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -56,8 +56,20 @@ type MixedQuestions =
  * our questions. This is one way we can tackle that.
  */
 const createQuestions = (data: any): MixedQuestions[] => {
-  const { templates } = data;
+  const { questions, templates } = data;
   const templateArray = fs.readdirSync(templates);
+
+  const templatingQuestions = questions?.map((question: string) => ({
+    name: question,
+    type: 'input',
+    message: `Output ${question}:`,
+    validate: Validation.required
+  })) ?? [{
+    name: 'name',
+    type: 'input',
+    message: 'Output name:',
+    validate: Validation.required
+  }];
 
   return [
     {
@@ -67,12 +79,7 @@ const createQuestions = (data: any): MixedQuestions[] => {
       message: 'Select a template:',
       choices: templateArray
     },
-    {
-      name: 'name',
-      type: 'input',
-      message: 'Output name:',
-      validate: Validation.required
-    }
+    ...templatingQuestions
   ];
 };
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -105,8 +105,10 @@ const generator = async (config: any) => {
   return await inquirer
     .prompt(questions)
     .then(async (answers: inquirer.Answers) => {
-      const { name, type } = answers;
-      const { templates } = config;
+      const { type } = answers;
+      const { folder, templates } = config;
+
+      const folderName = answers[folder] ?? answers[name];
 
       const fullConfig = { ...answers, ...config };
       const path = `${templates}/${type}`;
@@ -134,12 +136,12 @@ const generator = async (config: any) => {
         ...config,
         ...answers,
         ...templateAnswers,
-        name,
+        name: folderName,
         slug: 'TestingItOut'
       };
 
-      fs.mkdirSync(`${PATH_CURRENT}/${name}`);
-      copyTemplate(path, name, data);
+      fs.mkdirSync(`${PATH_CURRENT}/${folderName}`);
+      copyTemplate(path, folderName, data);
     });
 };
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -105,10 +105,10 @@ const generator = async (config: any) => {
   return await inquirer
     .prompt(questions)
     .then(async (answers: inquirer.Answers) => {
-      const { type } = answers;
+      const { name, type } = answers;
       const { folder, templates } = config;
 
-      const folderName = answers[folder] ?? answers[name];
+      const folderName = answers[folder] ?? name;
 
       const fullConfig = { ...answers, ...config };
       const path = `${templates}/${type}`;
@@ -136,7 +136,6 @@ const generator = async (config: any) => {
         ...config,
         ...answers,
         ...templateAnswers,
-        name: folderName,
         slug: 'TestingItOut'
       };
 


### PR DESCRIPTION
# Overview

Adds some config options to the generator, forked the repo since I couldn't push on the main branch.
The goal is to be able to use multiple template variables and and custom folder names for based on question answers.

CC: @visormatt 

